### PR TITLE
Use env as cname

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ environments:
 
     :aws {:access-key "XXXXXXXXXXXXXXXXXX"
           :secret-key "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"}
-          :beanstalk {:environments [myapp-dev]}}
+          :beanstalk {:environments [myapp-development myapp-staging myapp-production]}}
 
 You should now be able to deploy your application to the Amazon cloud
 using the following command:
@@ -34,22 +34,37 @@ using the following command:
 
 ### Info
 
-To get information about our environment  execute
+To get information about the application itself run
 
-    $ lein beanstalk info myapp-dev
+    $ lein beanstalk info
+    Application Name : myapp
+    Description      : My Awesome Compojure App
+    Last 5 Versions  : 0.1.0-20110209030504
+                       0.1.0-20110209030031
+                       0.1.0-20110209025533
+                       0.1.0-20110209021110
+                       0.1.0-20110209015216
+    Created On       : Wed Feb 09 03:00:45 EST 2011
+    Updated On       : Wed Feb 09 03:00:45 EST 2011
+    Deployed Envs    : myapp-development (Ready)
+                       myapp-staging (Ready)
+                       myapp-production (Terminated)
+
+and information about a particular environment execute
+
+    $ lein beanstalk info myapp-development
     Environment Id   : e-lm32mpkr6t
     Application Name : myapp
-    Environment Name : myapp-dev
+    Environment Name : myapp-development
     Description      : Default environment for the myapp application.
     URL              : myapp.elasticbeanstalk.com
     LoadBalancer URL : awseb-myapp-46156215.us-east-1.elb.amazonaws.com
     Status           : Ready
     Health           : Green
-    Current Version  : First Release
+    Current Version  : 0.1.0-20110209030504
     Solution Stack   : 32bit Amazon Linux running Tomcat 6
     Created On       : Tue Feb 08 08:01:44 EST 2011
     Updated On       : Tue Feb 08 08:05:01 EST 2011
-
 
 ## Trouble-Shooting
 

--- a/src/leiningen/aws.clj
+++ b/src/leiningen/aws.clj
@@ -129,6 +129,7 @@
        (.setApplicationName (:name project))
        (.setEnvironmentName environment)
        (.setVersionLabel (create-version project))
+       (.setCNAMEPrefix environment)
        (.setSolutionStackName solution-stack-name))))
 
 (defn- update-environment-request

--- a/src/leiningen/aws.clj
+++ b/src/leiningen/aws.clj
@@ -113,6 +113,13 @@
   [project]
   (.getApplications (.describeApplications (beanstalk-client project))))
 
+(defn get-application
+  "Returns the application matching the passed in name"
+  [project]
+  (when-let [app (filter #(and (= (.getApplicationName %) (:name project))                               )
+                         (describe-applications project))]
+    (first app)))
+
 ;; Environment
 (defn- create-environment-request
   ([project environment]
@@ -133,15 +140,16 @@
 
 (defn describe-environments
   [project]
-  (.getEnvironments (.describeEnvironments (beanstalk-client project))))
+  (filter #(and (= (.getApplicationName %) (:name project)))
+          (.getEnvironments (.describeEnvironments (beanstalk-client project)))))
 
 (defn get-environment
   "Returns the environment matching the passed in name"
   [project environment-name]
-  (when-let [env (filter #(and (= (.getApplicationName %) (:name project))
-                               (= (.getEnvironmentName %) environment-name))
-                         (describe-environments project))]
-    (first env)))
+  (when-let [envs (filter #(and (= (.getApplicationName %) (:name project))
+                                (= (.getEnvironmentName %) environment-name))
+                          (describe-environments project))]
+    (first envs)))
 
 (defn deploy-environment
   [project environment-name]

--- a/src/leiningen/beanstalk.clj
+++ b/src/leiningen/beanstalk.clj
@@ -26,7 +26,17 @@
 (defn info
   "Provides info for about project on Amazon Elastic Beanstalk."
   ([project]
-     (println "Usage: lein beanstalk info <environment>"))
+     (if-let [app (aws/get-application project)]
+       (do
+         (println (str "Application Name : " (.getApplicationName app)))
+         (println (str "Description      : " (.getDescription app)))
+         (println (str "Last 5 Versions  : " (join "\n                   " (take 5 (.getVersions app)))))
+         (println (str "Created On       : " (.getDateCreated app)))
+         (println (str "Updated On       : " (.getDateUpdated app)))
+         (println (str "Deployed Envs    : " (join "\n                   "
+                                                   (map #(str (.getEnvironmentName %) " (" (.getStatus %) ")")
+                                                        (aws/describe-environments project))))))
+       (println (str "Application '" (:name project) "' not found on AWS Elastic Beanstalk!"))))
   ([project environment-name]
      (if-not (project-env-exists? project environment-name)
        (println (str "Environment '" environment-name "' not in project.clj!"))


### PR DESCRIPTION
A small change. This will use the environment name as the preferred CNAME prefix. I found that useful, because otherwise AWS will create a URL name.

Fyi, I added this on top of the add-application-info branch.

-ck
