### PR TITLE
Add terminate env

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Leiningen plugin for Amazon's [Elastic Beanstalk][1]
 ## Prerequisites
 
 You will need an [Amazon Web Services][2] account, and know your
-account key and secret key. 
+account key and secret key.
 
 You will also need to be signed up for Elastic Beanstalk.
 
@@ -25,12 +25,14 @@ environments:
 
     :aws {:access-key "XXXXXXXXXXXXXXXXXX"
           :secret-key "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"}
-          :beanstalk {:environments [myapp-development myapp-staging myapp-production]}}
+          :beanstalk {:environments [development staging production]}}
+
+### Deploy
 
 You should now be able to deploy your application to the Amazon cloud
 using the following command:
 
-    lein beanstalk deploy myapp-dev
+    $ lein beanstalk deploy development
 
 ### Info
 
@@ -46,18 +48,18 @@ To get information about the application itself run
                        0.1.0-20110209015216
     Created On       : Wed Feb 09 03:00:45 EST 2011
     Updated On       : Wed Feb 09 03:00:45 EST 2011
-    Deployed Envs    : myapp-development (Ready)
-                       myapp-staging (Ready)
-                       myapp-production (Terminated)
+    Deployed Envs    : development (Ready)
+                       staging (Ready)
+                       production (Terminated)
 
 and information about a particular environment execute
 
-    $ lein beanstalk info myapp-development
+    $ lein beanstalk info development
     Environment Id   : e-lm32mpkr6t
     Application Name : myapp
-    Environment Name : myapp-development
+    Environment Name : development
     Description      : Default environment for the myapp application.
-    URL              : myapp.elasticbeanstalk.com
+    URL              : development-feihvibqb.elasticbeanstalk.com
     LoadBalancer URL : awseb-myapp-46156215.us-east-1.elb.amazonaws.com
     Status           : Ready
     Health           : Green
@@ -65,6 +67,16 @@ and information about a particular environment execute
     Solution Stack   : 32bit Amazon Linux running Tomcat 6
     Created On       : Tue Feb 08 08:01:44 EST 2011
     Updated On       : Tue Feb 08 08:05:01 EST 2011
+
+### Shutting Down
+
+To shutdown an existing environment use the following command
+
+    $ lein beanstalk terminate development
+
+This terminate the environment and all of its resources, i.e.
+the Auto Scaling group, LoadBalancer, etc.
+
 
 ## Trouble-Shooting
 

--- a/src/leiningen/beanstalk.clj
+++ b/src/leiningen/beanstalk.clj
@@ -25,6 +25,15 @@
          (aws/create-app-version project filename)
          (aws/deploy-environment project environment)))))
 
+(defn terminate
+  "Terminte the environment for the current project on Amazon Elastic Beanstalk."
+  ([project]
+     (println "Usage: lein beanstalk terminate <environment>"))
+  ([project env-name]
+     (if-not (project-env-exists? project env-name)
+       (println (str "Environment '" env-name "' not in project.clj"))
+       (aws/terminate-environment project env-name))))
+
 (def app-info-indent "\n                  ")
 
 (defn- last-versions-info [app]
@@ -78,11 +87,12 @@
 
 (defn beanstalk
   "Manage Amazon's Elastic Beanstalk service."
-  {:help-arglists '([deploy info])
-   :subtasks [#'deploy #'info]}
+  {:help-arglists '([deploy info terminate])
+   :subtasks [#'deploy #'info #'terminate]}
   ([project]
      (println (help-for "beanstalk")))
   ([project subtask & args]
     (case subtask
-      "deploy" (apply deploy project args)
-      "info"   (apply info project args))))
+      "deploy"    (apply deploy project args)
+      "info"      (apply info project args)
+      "terminate" (apply terminate project args))))

--- a/src/leiningen/beanstalk/aws.clj
+++ b/src/leiningen/beanstalk/aws.clj
@@ -14,6 +14,7 @@
     com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsRequest
     com.amazonaws.services.elasticbeanstalk.model.UpdateEnvironmentRequest
     com.amazonaws.services.elasticbeanstalk.model.S3Location
+    com.amazonaws.services.elasticbeanstalk.model.TerminateEnvironmentRequest
     com.amazonaws.services.s3.AmazonS3Client))
 
 (defn credentials [project]
@@ -95,3 +96,12 @@
   (if-let [env (get-environment project env-name)]
     (update-environment project env)
     (create-environment project env-name)))
+
+(defn terminate-environment
+  [project env-name]
+  (if-let [env (get-environment project env-name)]
+    (.terminateEnvironment
+     (beanstalk-client project)
+     (doto (TerminateEnvironmentRequest.)
+       (.setEnvironmentId (.getEnvironmentId env))
+       (.setEnvironmentName (.getEnvironmentName env))))))


### PR DESCRIPTION
Added the ability to terminate an environment on AWS Elastic Beanstalk and updated the README accordingly.

I tried to follow your coding style as much as possible to hopefully make it easier for you to merge the changes in. 

As always, if you see anything blatantly wrong, not idiomatic Clojure, or even not your coding style, I am more then interested to hear about it.

-ck
