### PR TITLE
Update aws java sdk

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,5 +2,5 @@
   :description "Leiningen plugin for Amazon's Elastic Beanstalk"
   :url "https://github.com/weavejester/lein-beanstalk"
   :dependencies [[org.clojure/clojure "1.2.0"]
-                 [com.amazonaws/aws-java-sdk "1.1.6"]
+                 [com.amazonaws/aws-java-sdk "1.1.7"]
                  [lein-ring "0.3.2"]])


### PR DESCRIPTION
Updated project to use latest AWS Java SDK (1.1.7).

-ck
