### PR TITLE
make beanstalk depend on lein-ring 0.4.5

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,4 +3,4 @@
   :url "https://github.com/weavejester/lein-beanstalk"
   :dependencies [[org.clojure/clojure "1.2.0"]
                  [com.amazonaws/aws-java-sdk "1.1.7"]
-                 [lein-ring "0.3.2"]])
+                 [lein-ring "0.4.5"]])


### PR DESCRIPTION
update dependency to current lein-ring (makes resources work as expected)

with current compojure/ring, resources need to be in the class path. the latest lein-ring does that correctly but lein-beanstalk uses an out-dated version of lein-ring. This patch fixes that.
