### PR TITLE
correct credentials-example

### DIFF
--- a/src/leiningen/beanstalk/aws.clj
+++ b/src/leiningen/beanstalk/aws.clj
@@ -26,7 +26,7 @@
      (setLevel Level/WARNING)))
 
 (def ^{:private true} credentials-example
-  "(def lein-beanstalk-credentials {:aws {:access-key \"XXX\" :secret-key \"YYY\"}})")
+  "(def lein-beanstalk-credentials {:access-key \"XXX\" :secret-key \"YYY\"})")
 
 (defn- find-credentials
   [project]


### PR DESCRIPTION
credentials-example incorrectly adds an :aws level to the config map.  :aws is only used in project.clj, not in the lein-beanstalk-credentials var.
