### PR TITLE
Fix region lookup

### DIFF
--- a/src/leiningen/beanstalk/aws.clj
+++ b/src/leiningen/beanstalk/aws.clj
@@ -72,7 +72,7 @@
    :us-west-2      "elasticbeanstalk.us-west-2.amazonaws.com"})
 
 (defn project-endpoint [project endpoints]
-  (-> project :aws (:region :us-east-1) keyword endpoints))
+  (-> project :aws :beanstalk (:region :us-east-1) keyword endpoints))
 
 (defn create-bucket [client bucket]
   (when-not (.doesBucketExist client bucket)


### PR DESCRIPTION
I noticed that no matter what I used for :region in the config, it would always default to us-east-1. Here's a patch that adds :beanstalk to the map lookup for region, which reflects what's in the README for the library.
