### PR TITLE
Note System/getProperty must be used to access environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ If the environment variable name is a keyword, it is upper-cased and
 underscores ("_") are substituted for dashes ("-"). e.g.
 `:database-url` becomes `"DATABASE_URL"`.
 
+Note that they will only be visible through System/getProperty and *NOT* System/getenv.
+
 ### S3 Buckets
 
 [Amazon Elastic Beanstalk][1] uses


### PR DESCRIPTION
Hi, I felt that adding clarification that System/getenv will not work would be helpful (in particular, for people migrating existing applications from Heroku where System/getenv is used to retrieve configuration information).
