### PR TITLE
Support passthrough of additional ConfigurationOptionSettings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,20 @@ If the environment variable name is a keyword, it is upper-cased and
 underscores ("_") are substituted for dashes ("-"). e.g.
 `:database-url` becomes `"DATABASE_URL"`.
 
+### Configuring instance type, autoscaling, VPC, SSH, AMI, SSL
+
+You can customize many [other settings][5] on a per beanstalk environment
+basis with an options key:
+
+    :aws
+    {:beanstalk
+     {:environments
+      [{:name "dev"
+        :options {"aws:autoscaling:asg" {"MinSize" "1" "MaxSize" "1"}
+                  "aws:autoscaling:launchconfiguration" {"InstanceType" "m1.medium"
+                                                         "EC2KeyName" "mykey"
+                                                         "ImageId" "ami-cbab67a2"}}}]}}
+
 ### S3 Buckets
 
 [Amazon Elastic Beanstalk][1] uses
@@ -240,3 +254,4 @@ application. e.g. for Compojure add
 [1]: http://aws.amazon.com/elasticbeanstalk
 [2]: http://aws.amazon.com
 [3]: http://aws.amazon.com/s3
+[5]: http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options.html

--- a/src/leiningen/beanstalk/aws.clj
+++ b/src/leiningen/beanstalk/aws.clj
@@ -140,6 +140,13 @@
        key)
      value)))
 
+(defn extra-options
+  [options]
+  (apply concat
+         (for [[namespace keyvals] options]
+           (for [[key value] keyvals]
+             (ConfigurationOptionSetting. namespace key value)))))
+
 (defn create-environment [project env]
   (println (str "Creating '" (:name env) "' environment")
            "(this may take several minutes)")
@@ -149,7 +156,8 @@
       (.setApplicationName (app-name project))
       (.setEnvironmentName (:name env))
       (.setVersionLabel   (app-version project))
-      (.setOptionSettings (env-var-options project env))
+      (.setOptionSettings (concat (env-var-options project env)
+                                  (extra-options (:options env))))
       (.setCNAMEPrefix (:cname-prefix env))
       (.setSolutionStackName (or (-> project :aws :beanstalk :stack-name)
                                  "32bit Amazon Linux running Tomcat 7")))))


### PR DESCRIPTION
Allows for per beanstalk environment configuration of things like:
- AMI used
- SSH key id
- Instance type used
- Auto scaling limits
- SSL certificate

Also added a section to the README documenting the feature with an example and a link to available options and their associated namespaces.
