### PR TITLE
fix bucket creation in non us-east-1 regions

### DIFF
--- a/src/leiningen/beanstalk/aws.clj
+++ b/src/leiningen/beanstalk/aws.clj
@@ -18,7 +18,8 @@
     com.amazonaws.services.elasticbeanstalk.model.UpdateEnvironmentRequest
     com.amazonaws.services.elasticbeanstalk.model.S3Location
     com.amazonaws.services.elasticbeanstalk.model.TerminateEnvironmentRequest
-    com.amazonaws.services.s3.AmazonS3Client))
+    com.amazonaws.services.s3.AmazonS3Client
+    com.amazonaws.services.s3.model.Region))
 
 (defn quiet-logger
   "Stop the extremely verbose AWS logger from logging so many messages."
@@ -57,33 +58,43 @@
   (or (-> project :aws :beanstalk :s3-bucket)
       (str "lein-beanstalk." (app-name project))))
 
+(defn- ep [endpoint region_name]
+  {:ep endpoint :region (Region/valueOf region_name)})
+
 (def s3-endpoints
-  {:us-east-1      "s3.amazonaws.com"
-   :ap-northeast-1 "s3-ap-northeast-1.amazonaws.com"
-   :eu-west-1      "s3-eu-west-1.amazonaws.com"
-   :us-west-1      "s3-us-west-1.amazonaws.com"
-   :us-west-2      "s3-us-west-2.amazonaws.com"})
+  {:us-east-1      (ep "s3.amazonaws.com" "US_Standard")
+   :us-west-1      (ep "s3-us-west-1.amazonaws.com" "US_West")
+   :us-west-2      (ep "s3-us-west-2.amazonaws.com" "US_West_2")
+   :eu-west-1      (ep "s3-eu-west-1.amazonaws.com" "EU_Ireland")
+   :ap-southeast-1 (ep "s3-ap-southeast-1.amazonaws.com" "AP_Singapore")
+   :ap-southeast-2 (ep "s3-ap-southeast-2.amazonaws.com" "AP_Sydney")
+   :ap-northeast-1 (ep "s3-ap-northeast-1.amazonaws.com" "AP_Tokyo")
+   :sa-east-1      (ep "s3-sa-east-1.amazonaws.com" "SA_SaoPaulo")})
 
 (def beanstalk-endpoints
   {:us-east-1      "elasticbeanstalk.us-east-1.amazonaws.com"
-   :ap-northeast-1 "elasticbeanstalk.ap-northeast-1.amazonaws.com"
-   :eu-west-1      "elasticbeanstalk.eu-west-1.amazonaws.com"
    :us-west-1      "elasticbeanstalk.us-west-1.amazonaws.com"
-   :us-west-2      "elasticbeanstalk.us-west-2.amazonaws.com"})
+   :us-west-2      "elasticbeanstalk.us-west-2.amazonaws.com"
+   :eu-west-1      "elasticbeanstalk.eu-west-1.amazonaws.com"
+   :ap-southeast-1 "elasticbeanstalk.ap-southeast-1.amazonaws.com"
+   :ap-southeast-2 "elasticbeanstalk.ap-southeast-2.amazonaws.com"
+   :ap-northeast-1 "elasticbeanstalk.ap-northeast-1.amazonaws.com"
+   :sa-east-1      "elasticbeanstalk.sa-east-1.amazonaws.com"})
 
 (defn project-endpoint [project endpoints]
   (-> project :aws :beanstalk (:region :us-east-1) keyword endpoints))
 
-(defn create-bucket [client bucket]
+(defn create-bucket [client bucket region]
   (when-not (.doesBucketExist client bucket)
-    (.createBucket client bucket)))
+    (.createBucket client bucket region)))
 
 (defn s3-upload-file [project filepath]
-  (let [bucket (s3-bucket-name project)
-        file   (io/file filepath)]
+  (let [bucket  (s3-bucket-name project)
+        file    (io/file filepath)
+        ep-desc (project-endpoint project s3-endpoints)]
     (doto (AmazonS3Client. (credentials project))
-      (.setEndpoint (project-endpoint project s3-endpoints))
-      (create-bucket bucket)
+      (.setEndpoint (:ep ep-desc))
+      (create-bucket bucket (:region ep-desc))
       (.putObject bucket (.getName file) file))
     (println "Uploaded" (.getName file) "to S3 Bucket")))
 


### PR DESCRIPTION
So AFAIK when creating a bucket you need to be connected
to the right endpoint and also set the region correctly.

The region defaults to us-east-1, so this worked
in those cases but now it should work in international regions.

See:
http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/Region.html
http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3.html#createBucket(java.lang.String, com.amazonaws.services.s3.model.Region)
