### PR TITLE
Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then add a `lein-beanstalk-credentials` definition to your
 ```
 
 Or, if you're using Leiningen 2, you can add the credentials to your
-`~/.lein/profile.clj` file:
+`~/.lein/profiles.clj` file:
 ```clojure
 {:user
  {:aws {:access-key "XXXXXXXXXXXXXXXXXX"


### PR DESCRIPTION
https://github.com/technomancy/leiningen/blob/master/doc/PROFILES.md

I believe this is a typo
