### PR TITLE
Added ability to pull in .ebextensions conf files

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-beanstalk "0.2.7"
+(defproject lein-beanstalk "0.2.8"
   :description "Leiningen plugin for Amazon's Elastic Beanstalk"
   :url "https://github.com/weavejester/lein-beanstalk"
   :dependencies [[org.clojure/clojure "1.2.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject lein-beanstalk "0.2.8"
+(defproject zimilate/lein-beanstalk "0.2.15"
   :description "Leiningen plugin for Amazon's Elastic Beanstalk"
-  :url "https://github.com/weavejester/lein-beanstalk"
+  :url "https://github.com/johnaschroeder/lein-beanstalk"
   :dependencies [[org.clojure/clojure "1.2.1"]
                  [com.amazonaws/aws-java-sdk "1.3.31"]
                  [lein-ring "0.8.2"]]

--- a/src/leiningen/beanstalk.clj
+++ b/src/leiningen/beanstalk.clj
@@ -34,12 +34,20 @@
   ([project]
      (println "Usage: lein beanstalk deploy <environment>"))
   ([project env-name]
+     (deploy project env-name false))
+  ([project env-name aws]
      (if-let [env (get-project-env project env-name)]
-       (let [filename (war-filename project)
-             path (uberwar project filename)]
-         (aws/s3-upload-file project path)
-         (aws/create-app-version project filename)
-         (aws/deploy-environment project env))
+        (if aws)
+         (let [filename (war-filename project)
+               path (awsuberwar project filename)]
+           (aws/s3-upload-file project path)
+           (aws/create-app-version project filename)
+           (aws/deploy-environment project env))
+         (let [filename (war-filename project)
+               path (uberwar project filename)]
+           (aws/s3-upload-file project path)
+           (aws/create-app-version project filename)
+           (aws/deploy-environment project env))
        (println (str "Environment '" env-name "' not defined!")))))
 
 (defn terminate


### PR DESCRIPTION
Added the ability to pull in eb config and conf files that execute commands on the ec2 instance, as ring ignores any hidden directories by default.  Among other things, this allows you to add gzip compression as described here:
http://www.tonmoygoswami.com/2013/05/how-to-enable-gzip-on-amazon-elastic.html

The basic functions to allow the .ebextensions directory was take from here:
https://github.com/snowplow/snowplow/blob/master/2-collectors/clojure-collector/tasks/leiningen/aws.clj
